### PR TITLE
Add optional CA Cert

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,7 @@
 const { SecretClient } = require("@azure/keyvault-secrets");
 const { DefaultAzureCredential } = require("@azure/identity");
+const fs = require('fs');
+require("dotenv").config();
 
 const logAppName = '[azure-keyvault-secrets]';
 

--- a/app.js
+++ b/app.js
@@ -24,7 +24,17 @@ const getKeyVaultSecret = async function (keyVaultName, secretName) {
 
     const credential = new DefaultAzureCredential();
     const url = `https://${keyVaultName}.vault.azure.net`;
-    const client = new SecretClient(url, credential);
+
+    var clientOptions = undefined;
+    if (process.env.NODE_EXTRA_CA_CERTS) {
+        clientOptions = {
+            tlsOptions: {
+                ca: fs.readFileSync(process.env.NODE_EXTRA_CA_CERTS)
+            }
+        };
+    }
+
+    const client = new SecretClient(url, credential, clientOptions);
 
     try {
         const secret = await client.getSecret(secretName);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "insomnia-plugin-azure-keyvault-secrets",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "insomnia-plugin-azure-keyvault-secrets",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^3.2.3",
-        "@azure/keyvault-secrets": "^4.7.0"
+        "@azure/keyvault-secrets": "^4.7.0",
+        "dotenv": "^16.3.1"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -293,6 +294,17 @@
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/ecdsa-sig-formatter": {
@@ -758,6 +770,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+    },
+    "dotenv": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ=="
     },
     "ecdsa-sig-formatter": {
       "version": "1.0.11",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "description": "An Insomnia plugin to get secrets from Azure Key Vault",
   "dependencies": {
     "@azure/identity": "^3.2.3",
-    "@azure/keyvault-secrets": "^4.7.0"
+    "@azure/keyvault-secrets": "^4.7.0",
+    "dotenv": "^16.3.1"
   }
 }


### PR DESCRIPTION
Issue: When using this package behind a corporate network, a `RestError: self signed certificate in certificate chain` error occurs when attempting to interact with Azure's secret client. To resolve this issue, typically a `NODE_EXTRA_CA_CERTS` environment variable is added with a path to the additional certs required to validate the ssl request. However, it seems the SecretClient does not look for this environment variable by default.

Proposed Resolution: To resolve this issue following current conventions, I have updated this package to look for an optional `NODE_EXTRA_CA_CERTS` environment variable and inject it into the tls settings of the SecretClient if the variable is found.
